### PR TITLE
Add sender to voting power change

### DIFF
--- a/subgraphs/maker-governance/protocols/maker-governance/config/deployments/maker-governance-ethereum/configurations.json
+++ b/subgraphs/maker-governance/protocols/maker-governance/config/deployments/maker-governance-ethereum/configurations.json
@@ -1,7 +1,7 @@
 {
   "network": "mainnet",
-  "governorContractAddress": "0x0a3f6849f78076aefadf113f5bed87720274ddc0",
-  "governorContractStartBlock": 11327777,
+  "dsChiefContractAddress": "0x0a3f6849f78076aefadf113f5bed87720274ddc0",
+  "dsChiefContractStartBlock": 11327777,
   "pollingContractAddress": "0xf9be8f0945acddeedaa64dfca5fe9629d0cf8e5d",
   "pollingContractStartBlock": 8122207,
   "tokenContractAddress": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",

--- a/subgraphs/maker-governance/protocols/maker-governance/config/templates/maker-governance.template.yaml
+++ b/subgraphs/maker-governance/protocols/maker-governance/config/templates/maker-governance.template.yaml
@@ -7,9 +7,9 @@ dataSources:
     name: DSChief
     network: {{ network }}
     source:
-      address: "{{ governorContractAddress }}"
+      address: "{{ dsChiefContractAddress }}"
       abi: DSChief
-      startBlock: {{ governorContractStartBlock }}
+      startBlock: {{ dsChiefContractStartBlock }}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5

--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -62,14 +62,14 @@ export function handleLock(event: LogNote): void {
     }
   }
 
-  const delegateVPChange = createDelegateVotingPowerChange(
-    event,
-    delegate.votingPowerRaw,
-    delegate.votingPowerRaw.plus(amount),
-    delegate.id,
-    sender.toHexString()
-  );
-  delegateVPChange.save();
+  // const delegateVPChange = createDelegateVotingPowerChange(
+  //   event,
+  //   delegate.votingPowerRaw,
+  //   delegate.votingPowerRaw.plus(amount),
+  //   delegate.id,
+  //   sender.toHexString()
+  // );
+  // delegateVPChange.save();
 
   delegate.votingPowerRaw = delegate.votingPowerRaw.plus(amount);
   delegate.votingPower = delegate.votingPower.plus(toDecimal(amount));
@@ -90,14 +90,14 @@ export function handleFree(event: LogNote): void {
 
   const delegate = getDelegate(sender.toHexString());
 
-  const delegateVPChange = createDelegateVotingPowerChange(
-    event,
-    delegate.votingPowerRaw,
-    delegate.votingPowerRaw.minus(amount),
-    delegate.id,
-    sender.toHexString()
-  );
-  delegateVPChange.save();
+  // const delegateVPChange = createDelegateVotingPowerChange(
+  //   event,
+  //   delegate.votingPowerRaw,
+  //   delegate.votingPowerRaw.minus(amount),
+  //   delegate.id,
+  //   sender.toHexString()
+  // );
+  // delegateVPChange.save();
 
   delegate.votingPowerRaw = delegate.votingPowerRaw.minus(amount);
   delegate.votingPower = delegate.votingPower.minus(toDecimal(amount));

--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -66,7 +66,8 @@ export function handleLock(event: LogNote): void {
     event,
     delegate.votingPowerRaw,
     delegate.votingPowerRaw.plus(amount),
-    delegate.id
+    delegate.id,
+    sender.toHexString()
   );
   delegateVPChange.save();
 
@@ -93,7 +94,8 @@ export function handleFree(event: LogNote): void {
     event,
     delegate.votingPowerRaw,
     delegate.votingPowerRaw.minus(amount),
-    delegate.id
+    delegate.id,
+    sender.toHexString()
   );
   delegateVPChange.save();
 

--- a/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/ds-chief.ts
@@ -42,7 +42,7 @@ export function handleLock(event: LogNote): void {
     delegate.tokenHoldersRepresented = 0;
     delegate.currentSpells = [];
     delegate.numberVotes = 0;
-    delegate.numberPoleVotes = 0;
+    delegate.numberPollVotes = 0;
 
     // Check if vote delegate contract by calling chief()
     const voteDelegate = VoteDelegate.bind(sender);

--- a/subgraphs/maker-governance/protocols/maker-governance/src/polling-emitter.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/polling-emitter.ts
@@ -8,7 +8,7 @@ export function handlePollVote(event: Voted): void {
   const optionId = event.params.optionId;
 
   const delegate = getDelegate(voter);
-  delegate.numberPoleVotes = delegate.numberPoleVotes + 1;
+  delegate.numberPollVotes = delegate.numberPollVotes + 1;
   delegate.save();
 
   let poll = Poll.load(pollId);

--- a/subgraphs/maker-governance/protocols/maker-governance/src/vote-delegate.ts
+++ b/subgraphs/maker-governance/protocols/maker-governance/src/vote-delegate.ts
@@ -28,7 +28,8 @@ export function handleDelegateLock(event: Lock): void {
     event,
     delegation.amount,
     delegation.amount.plus(event.params.wad),
-    delegate.id
+    delegate.id,
+    sender
   );
   delegateVPChange.save();
 
@@ -56,7 +57,8 @@ export function handleDelegateFree(event: Free): void {
     event,
     delegation.amount,
     delegation.amount.minus(event.params.wad),
-    delegate.id
+    delegate.id,
+    sender
   );
   delegateVPChange.save();
 

--- a/subgraphs/maker-governance/schema.graphql
+++ b/subgraphs/maker-governance/schema.graphql
@@ -135,9 +135,9 @@ type Delegate @entity {
   numberVotes: Int!
 
   "Poll votes associated to this spell"
-  poleVotes: [PollVote!]! @derivedFrom(field: "voter")
+  pollVotes: [PollVote!]! @derivedFrom(field: "voter")
   "Number of spells voted on"
-  numberPoleVotes: Int!
+  numberPollVotes: Int!
 }
 type Delegation @entity {
   "delegate-delegator"
@@ -216,5 +216,5 @@ type Poll @entity {
   "Poll's id"
   id: String!
   "Poll votes associated to this spell"
-  polevotes: [PollVote!]! @derivedFrom(field: "poll")
+  pollVotes: [PollVote!]! @derivedFrom(field: "poll")
 }

--- a/subgraphs/maker-governance/schema.graphql
+++ b/subgraphs/maker-governance/schema.graphql
@@ -156,6 +156,8 @@ type DelegateVotingPowerChange @entity(immutable: true) {
   "Token address for delegate"
   delegate: String!
   "Previous voting power of delegate"
+  sender: String!
+  "Sender of the voting power change transaction"
   previousBalance: BigInt!
   "New voting power of delegate"
   newBalance: BigInt!

--- a/subgraphs/maker-governance/src/helpers.ts
+++ b/subgraphs/maker-governance/src/helpers.ts
@@ -55,7 +55,7 @@ export function getDelegate(address: string): Delegate {
     delegate.tokenHoldersRepresented = 0;
     delegate.currentSpells = [];
     delegate.numberVotes = 0;
-    delegate.numberPoleVotes = 0;
+    delegate.numberPollVotes = 0;
   }
   return delegate;
 }

--- a/subgraphs/maker-governance/src/helpers.ts
+++ b/subgraphs/maker-governance/src/helpers.ts
@@ -64,7 +64,8 @@ export function createDelegateVotingPowerChange(
   event: ethereum.Event,
   previousBalance: BigInt,
   newBalance: BigInt,
-  delegate: string
+  delegate: string,
+  sender: string
 ): DelegateVotingPowerChange {
   const delegateVotingPwerChangeId = `${event.block.timestamp.toI64()}-${
     event.logIndex
@@ -75,6 +76,7 @@ export function createDelegateVotingPowerChange(
   delegateVPChange.previousBalance = previousBalance;
   delegateVPChange.newBalance = newBalance;
   delegateVPChange.delegate = delegate;
+  delegateVPChange.sender = sender;
   delegateVPChange.tokenAddress = event.address.toHexString();
   delegateVPChange.txnHash = event.transaction.hash.toHexString();
   delegateVPChange.blockTimestamp = event.block.timestamp;


### PR DESCRIPTION
This PR adds the sender address to the delegate voting power change record.

It also stops creating a delegate voting power change record for ds-chief as it seems to be a duplicate of the VPC on the vote delegate contract.